### PR TITLE
Update plugin.info.txt

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   groupmail
 author Roland Wunderling
 email  bzfwunde@gmail.com
-date   2015-09-27
+date   2016-05-31
 name   Group mailing system
 desc   Allows to include mailing form to wiki page from which to send
        email to a preconfigures


### PR DESCRIPTION
date updated to the current version to prevent that the plugin keeps being listed with an available update in Dokuwiki's Plugin Manager...